### PR TITLE
Move HomeDicator settings to a 'package' yaml file

### DIFF
--- a/ESPHome/HomeDicator.yaml
+++ b/ESPHome/HomeDicator.yaml
@@ -5,9 +5,10 @@ substitutions:
   device_name: "homedicator"
   device_friendly_name: "HomeDicator"
 
-  # --------------------------
+  # ---------------------------------------------------------------------------------
   # ENTER API AND OTA KEY HERE
-  # --------------------------
+  # Add the keys to your secret file or change them here if you want individual keys.
+  # ---------------------------------------------------------------------------------
   api_key: !secret api_encryption_key
   ota_key: !secret ota_password
 

--- a/ESPHome/HomeDicator.yaml
+++ b/ESPHome/HomeDicator.yaml
@@ -8,8 +8,8 @@ substitutions:
   # --------------------------
   # ENTER API AND OTA KEY HERE
   # --------------------------
-  api_key: "<api-key>"
-  ota_key: "<ota-key>"
+  api_key: !secret api_encryption_key
+  ota_key: !secret ota_password
 
   # ------------------------------
   # ADJUST YOUR WLAN SETTINGS HERE
@@ -26,11 +26,15 @@ substitutions:
   # OTHER SETTINGS
   # --------------
   user_interface_debug_mode: "false" # Draws borders around objects and labels for layouting
-     
+
+packages:
+  HomeDicator: !include HomeDicator/core.yaml
+
 sensor:
   # ----------------------------------------------------------------------
   # ADD YOUR SENSORS HERE
   # Because of the way ESPHOME works lights, thermostats, etc also go here
+  # They need to be included here in order for display to update values.
   # ----------------------------------------------------------------------
 
   - !include 
@@ -41,37 +45,17 @@ sensor:
   - !include 
       file: HomeDicator/core/templates/climate_sensor.yaml
       vars:
-        hass_climate_id: "example_climate_id_change_me" # You can ommit the "climate."
-
-  # ----------------------------
-  # INTERNAL SENSORS DON'T TOUCH
-  # ----------------------------
-  - !include HomeDicator/core/config/sensors/wifi_signal.yaml
-  - !include HomeDicator/core/config/sensors/wifi_signal_percent.yaml
-  
+         hass_climate_id: "example_climate_id_change_me" # You can ommit the "climate."
 
 binary_sensor:
   # ---------------------
   # ADD YOUR SENSORS HERE
   # ---------------------
 
-
-  # ----------------------------
-  # INTERNAL SENSORS DON'T TOUCH
-  # ----------------------------
-  - !include HomeDicator/core/config/binary_sensors/indicator_button.yaml
-         
 switch:
   # ----------------------
   # ADD YOUR SWITCHES HERE
   # ----------------------
-
-
-  # -----------------------------
-  # INTERNAL SWITCHES DON'T TOUCH
-  # -----------------------------
-  - !include HomeDicator/core/config/switches/use_24h_clock_switch.yaml
-
 
 lvgl:  
   pages:
@@ -109,34 +93,3 @@ lvgl:
                     min_value: 5
                     max_value: 25
                     title: "Living Room"
-   
-
-
-   # ---------------------------
-   # SETTINGS PAGE - DON'T TOUCH
-   # ---------------------------
-    - !include HomeDicator/user_interface/pages/settings.yaml
-
-
-  # ----------------------
-  # INTERNAL - DON'T TOUCH
-  # ----------------------
-  disp_bg_color: 0x1b1b1b
-  gradients: !include HomeDicator/core/config/lvgl/gradients.yaml
-  on_idle: !include HomeDicator/core/config/lvgl/on_idle.yaml
-  top_layer: !include HomeDicator/user_interface/pages/top_layer/top_layer.yaml
-  theme: !include HomeDicator/user_interface/theme/theme.yaml
-  style_definitions: !include HomeDicator/user_interface/theme/style_definitions.yaml
-
-
-# ----------------------
-# INTERNAL - DON'T TOUCH
-# ----------------------
-<<: !include HomeDicator/core/config/fonts.yaml
-<<: !include HomeDicator/core/config/esphome.yaml
-<<: !include HomeDicator/core/config/hardware.yaml
-<<: !include HomeDicator/core/config/scripts.yaml
-<<: !include HomeDicator/core/config/light.yaml
-<<: !include HomeDicator/core/config/time.yaml
-<<: !include HomeDicator/core/config/select.yaml
-<<: !include HomeDicator/core/config/globals.yaml

--- a/ESPHome/HomeDicator/core.yaml
+++ b/ESPHome/HomeDicator/core.yaml
@@ -1,0 +1,49 @@
+---
+sensor:
+  # ----------------------------
+  # INTERNAL SENSORS DON'T TOUCH
+  # ----------------------------
+  - !include core/config/sensors/wifi_signal.yaml
+  - !include core/config/sensors/wifi_signal_percent.yaml
+
+binary_sensor:
+  # ----------------------------
+  # INTERNAL SENSORS DON'T TOUCH
+  # ----------------------------
+  - !include core/config/binary_sensors/indicator_button.yaml
+         
+switch:
+  # -----------------------------
+  # INTERNAL SWITCHES DON'T TOUCH
+  # -----------------------------
+  - !include core/config/switches/use_24h_clock_switch.yaml
+
+lvgl:
+  pages:
+   # ---------------------------
+   # SETTINGS PAGE - DON'T TOUCH
+   # ---------------------------
+    - !include user_interface/pages/settings.yaml
+
+  # ----------------------
+  # INTERNAL - DON'T TOUCH
+  # ----------------------
+  disp_bg_color: 0x1b1b1b
+  gradients: !include core/config/lvgl/gradients.yaml
+  on_idle: !include core/config/lvgl/on_idle.yaml
+  top_layer: !include user_interface/pages/top_layer/top_layer.yaml
+  theme: !include user_interface/theme/theme.yaml
+  style_definitions: !include user_interface/theme/style_definitions.yaml
+
+# ----------------------
+# INTERNAL - DON'T TOUCH
+# ----------------------
+<<: !include core/config/fonts.yaml
+<<: !include core/config/esphome.yaml
+<<: !include core/config/hardware.yaml
+<<: !include core/config/scripts.yaml
+<<: !include core/config/light.yaml
+<<: !include core/config/time.yaml
+<<: !include core/config/select.yaml
+<<: !include core/config/globals.yaml
+

--- a/ESPHome/HomeDicator/core/config/esphome.yaml
+++ b/ESPHome/HomeDicator/core/config/esphome.yaml
@@ -15,6 +15,11 @@ esphome:
     - priority: 800.0
       then:
         - script.execute: create_pager_dots
+    - priority: 250.0
+      then:
+        # Using ESPhome packages will cause the settings page to be the first one, lvgl.page.next will make it look like the last one again.
+        - lvgl.page.next:
+            animation: NONE
     - priority: 200.0
       then:
         - select.set_index:

--- a/ESPHome/HomeDicator/core_sdl.yaml
+++ b/ESPHome/HomeDicator/core_sdl.yaml
@@ -1,0 +1,47 @@
+---
+sensor:
+  # ----------------------------
+  # INTERNAL SENSORS DON'T TOUCH
+  # ----------------------------
+
+binary_sensor:
+  # ----------------------------
+  # INTERNAL SENSORS DON'T TOUCH
+  # ----------------------------
+  - !include core/config/binary_sensors/indicator_button.yaml
+         
+switch:
+  # -----------------------------
+  # INTERNAL SWITCHES DON'T TOUCH
+  # -----------------------------
+  - !include core/config/switches/use_24h_clock_switch.yaml
+
+lvgl:
+  pages:
+   # ---------------------------
+   # SETTINGS PAGE - DON'T TOUCH
+   # ---------------------------
+    - !include user_interface/pages/settings.yaml
+
+  # ----------------------
+  # INTERNAL - DON'T TOUCH
+  # ----------------------
+  disp_bg_color: 0x1b1b1b
+  gradients: !include core/config/lvgl/gradients.yaml
+  on_idle: !include core/config/lvgl/on_idle.yaml
+  top_layer: !include user_interface/pages/top_layer/top_layer.yaml
+  theme: !include user_interface/theme/theme.yaml
+  style_definitions: !include user_interface/theme/style_definitions.yaml
+
+# ----------------------
+# INTERNAL - DON'T TOUCH
+# ----------------------
+<<: !include core/config/fonts.yaml
+<<: !include core/config/esphome.yaml
+<<: !include core/config/hardware_development.yaml
+<<: !include core/config/scripts.yaml
+<<: !include core/config/light.yaml
+<<: !include core/config/time.yaml
+<<: !include core/config/select.yaml
+<<: !include core/config/globals.yaml
+

--- a/ESPHome/HomeDicator_SDL_Development.yaml
+++ b/ESPHome/HomeDicator_SDL_Development.yaml
@@ -19,12 +19,16 @@ substitutions:
   # OTHER SETTINGS
   # --------------
   user_interface_debug_mode: "false" # Draws borders around objects and labels for layouting
-     
+  
+packages:
+  HomeDicator: !include HomeDicator/core_sdl.yaml
+  
 sensor:
-  # ----------------------------------------------------------------------
+  # -----------------------------------------------------------------------
   # ADD YOUR SENSORS HERE
   # Because of the way ESPHOME works lights, thermostats, etc also go here
-  # ----------------------------------------------------------------------
+  # They need to be included here in order for the display to update values.
+  # -----------------------------------------------------------------------
 
   - !include 
       file: HomeDicator/core/templates/sensor.yaml
@@ -68,22 +72,12 @@ binary_sensor:
   # ADD YOUR SENSORS HERE
   # ---------------------
 
-
-  # ----------------------------
-  # INTERNAL SENSORS DON'T TOUCH
-  # ----------------------------
-  - !include HomeDicator/core/config/binary_sensors/indicator_button.yaml
          
 switch:
   # ----------------------
   # ADD YOUR SWITCHES HERE
   # ----------------------
 
-
-  # -----------------------------
-  # INTERNAL SWITCHES DON'T TOUCH
-  # -----------------------------
-  - !include HomeDicator/core/config/switches/use_24h_clock_switch.yaml
 
 
 lvgl:  
@@ -181,34 +175,3 @@ lvgl:
                     icon: "\U000F013B"
                     unit: "µg/m³"
                     title: "Bedroom"
-              
-
-
-   # ---------------------------
-   # SETTINGS PAGE - DON'T TOUCH
-   # ---------------------------
-    - !include HomeDicator/user_interface/pages/settings.yaml
-
-
-  # ----------------------
-  # INTERNAL - DON'T TOUCH
-  # ----------------------
-  disp_bg_color: 0x1b1b1b
-  gradients: !include HomeDicator/core/config/lvgl/gradients.yaml
-  on_idle: !include HomeDicator/core/config/lvgl/on_idle.yaml
-  top_layer: !include HomeDicator/user_interface/pages/top_layer/top_layer.yaml
-  theme: !include HomeDicator/user_interface/theme/theme.yaml
-  style_definitions: !include HomeDicator/user_interface/theme/style_definitions.yaml
-
-
-# ----------------------
-# INTERNAL - DON'T TOUCH
-# ----------------------
-<<: !include HomeDicator/core/config/fonts.yaml
-<<: !include HomeDicator/core/config/esphome.yaml
-<<: !include HomeDicator/core/config/hardware_development.yaml
-<<: !include HomeDicator/core/config/scripts.yaml
-<<: !include HomeDicator/core/config/light.yaml
-<<: !include HomeDicator/core/config/time.yaml
-<<: !include HomeDicator/core/config/select.yaml
-<<: !include HomeDicator/core/config/globals.yaml


### PR DESCRIPTION
This simplifies the top level device yaml file. The following issues exist:

- The 'packages' section will merge the sections of a file with the top level configuration. Currently, the merge for lists is done as a concatenation from the front. This causes the 'setting' page to be the first page shown, rather than the last. I don't know how this can be fixed.

- The 'api_key' and 'ota_key' definitions have been added to 'secret.yaml'