### PR TITLE
Allow touches on the label text

### DIFF
--- a/HomeDicator/user_interface/templates/tiles/thermostat/wide.yaml
+++ b/HomeDicator/user_interface/templates/tiles/thermostat/wide.yaml
@@ -7,7 +7,7 @@ obj:
     - obj:
         styles: info_or_button_tile_wide
         width: 440
-        layout: 
+        layout:
           type: FLEX
           flex_flow: COLUMN
           flex_align_main: START
@@ -52,13 +52,14 @@ obj:
                       value: 'false'
               on_value: !include helpers/on_value.yaml
     - obj:
+        clickable: false
         bg_opa: TRANSP
         width: SIZE_CONTENT
         height: SIZE_CONTENT
         pad_all: 0
         x: 50
         y: 75
-        layout: 
+        layout:
           type: FLEX
           flex_flow: ROW
           flex_align_main: CENTER
@@ -75,4 +76,3 @@ obj:
               text_font: libreFranklin25Light
               text_color: 0xffffff
               text: "${unit}"
-    

--- a/HomeDicator/user_interface/templates/tiles/thermostat/wide_half_height.yaml
+++ b/HomeDicator/user_interface/templates/tiles/thermostat/wide_half_height.yaml
@@ -10,7 +10,7 @@ obj:
         height: 78
         pad_left: 25
         pad_right: 11
-        layout: 
+        layout:
           type: FLEX
           flex_flow: ROW
           flex_align_main: SPACE_BETWEEN
@@ -66,13 +66,14 @@ obj:
                       value: 'false'
               on_value: !include helpers/on_value.yaml
     - obj:
+        clickable: false
         bg_opa: TRANSP
         width: SIZE_CONTENT
         height: SIZE_CONTENT
         pad_all: 0
         x: 155
         y: 23
-        layout: 
+        layout:
           type: FLEX
           flex_flow: ROW
           flex_align_main: CENTER
@@ -89,4 +90,3 @@ obj:
               text_font: libreFranklin20Light
               text_color: 0xffffff
               text: "${unit}"
-    

--- a/HomeDicator/user_interface/templates/tiles/thermostat/wide_half_height_icon_right.yaml
+++ b/HomeDicator/user_interface/templates/tiles/thermostat/wide_half_height_icon_right.yaml
@@ -10,7 +10,7 @@ obj:
         height: 78
         pad_right: 25
         pad_left: 11
-        layout: 
+        layout:
           type: FLEX
           flex_flow: ROW
           flex_align_main: SPACE_BETWEEN
@@ -48,7 +48,7 @@ obj:
                       id: user_is_interacting
                       value: 'false'
               on_value: !include helpers/on_value.yaml
-              
+
           - obj:
               bg_opa: COVER
               bg_color: ${color}
@@ -67,13 +67,14 @@ obj:
                     styles: info_or_button_tile_icon
                     text: ${icon}
     - obj:
+        clickable: false
         bg_opa: TRANSP
         width: SIZE_CONTENT
         height: SIZE_CONTENT
         pad_all: 0
         x: 28
         y: 23
-        layout: 
+        layout:
           type: FLEX
           flex_flow: ROW
           flex_align_main: CENTER
@@ -90,4 +91,3 @@ obj:
               text_font: libreFranklin20Light
               text_color: 0xffffff
               text: "${unit}"
-    


### PR DESCRIPTION
The object holding the current temperature and unit labels blocked interacting with the slider behind them, adding `clickable: false` fixes this.