### PR TITLE
Expose WiFi Domain and Reboot Timeout for configuration (plus add bench icon)

### DIFF
--- a/HomeDicator/core/config/common/fonts.yaml
+++ b/HomeDicator/core/config/common/fonts.yaml
@@ -24,6 +24,7 @@ font:
       "\U000F0FD2", # mdi:bed-king
       "\U000F0FD1", # mdi:bed-king-outline
       "\U000F08A0", # mdi:bed-empty
+      "\U000F1C21", # mdi:bench
       "\U000F00DE", # mdi:brightness-5
       "\U000F1302", # mdi:bunk-bed
       "\U000F0097", # mdi:bunk-bed-outline

--- a/HomeDicator/core/config/device/seeed-sensecap-indicator/hardware.yaml
+++ b/HomeDicator/core/config/device/seeed-sensecap-indicator/hardware.yaml
@@ -109,6 +109,8 @@ ota:
 wifi:
   ssid: ${wifi_ssid}
   password: ${wifi_password}
+  domain: ${wifi_domain}
+  reboot_timeout: ${wifi_reboot_timeout}
   on_disconnect:
       - lvgl.label.update:
           id: lvgl_wifi_signal_icon


### PR DESCRIPTION
This PR (and a companion in the templates repo) expose the wifi_domain and reboot_timeout WiFi settings for user configuration. I needed to set the reboot timeout to get stable WiFi, and also wanted to set the domain.
While I was at it I added the `mdi:bench` icon, which may or may not be appropriate for this PR...